### PR TITLE
fix: allow leveldb storage to start twice

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,21 +47,10 @@
       "type": "node"
     },
     {
-      "cwd": "${workspaceFolder}/packages/database",
-      "type": "node",
+      "command": "npm run test",
+      "name": "Test2",
       "request": "launch",
-      "console": "integratedTerminal",
-      "name": "TEST",
-      "program": "${workspaceRoot}/node_modules/.bin/vitest",
-      "args": [
-        "--pool",
-        "threads",
-        "--poolOptions.threads.singleThread",
-      ],
-      "skipFiles": [
-        "${workspaceRoot}/../../node_modules/**/*",
-        "<node_internals>/**/*"
-      ]
+      "type": "node-terminal"
     }
   ]
 }

--- a/packages/leveldb/.gitignore
+++ b/packages/leveldb/.gitignore
@@ -1,0 +1,2 @@
+db*
+prism-db

--- a/packages/leveldb/src/index.ts
+++ b/packages/leveldb/src/index.ts
@@ -66,7 +66,7 @@ function getRxStorageLevel<RxDocType>(settings: LevelDBSettings): RxStorageLevel
                 };
 
             const databasePath = "level" in levelDBConstructorProps ?
-                levelDBConstructorProps.level.path :
+                levelDBConstructorProps.level.db.location :
                 levelDBConstructorProps.dbPath;
 
             const existingInstance = internalInstance.get(databasePath);

--- a/packages/leveldb/src/index.ts
+++ b/packages/leveldb/src/index.ts
@@ -35,7 +35,6 @@ export type { DefaultPreparedQuery, RxJsonSchema, FilledMangoQuery, CompressionM
 export type { Level } from 'level'
 let internalInstance: LevelDBInternal<any>
 export const RX_STORAGE_NAME_LEVELDB = 'leveldb';
-let levelDBInstance: RxStorageLevelDBType<any>;
 
 async function preloadData<RxDocType>(constructorProps: LevelDBInternalConstructor<RxDocType>) {
     try {
@@ -48,48 +47,43 @@ async function preloadData<RxDocType>(constructorProps: LevelDBInternalConstruct
 }
 
 function getRxStorageLevel<RxDocType>(settings: LevelDBSettings): RxStorageLevelDBType<RxDocType> {
-    if (true) {
-        levelDBInstance = {
-            name: RX_STORAGE_NAME_LEVELDB,
-            statics: RxStorageDefaultStatics,
-            async createStorageInstance<RxDocType>(params: RxStorageInstanceCreationParams<RxDocType, LevelDBSettings>): Promise<RxStorageInstance<RxDocType, LevelDBStorageInternals<RxDocType>, LevelDBSettings, any>> {
-                const levelDBConstructorProps: LevelDBInternalConstructor<RxDocType> = "level" in settings ?
-                    {
-                        level: settings.level,
-                        refCount: 1,
-                        schema: params.schema,
-                    }
-                    :
-                    {
-                        dbPath: settings.dbPath,
-                        refCount: 1,
-                        schema: params.schema,
-                    };
-
-                if (!internalInstance) {
-                    internalInstance = await preloadData<RxDocType>(levelDBConstructorProps);
-                } else {
-                    internalInstance.refCount++
+    const instance: RxStorageLevelDBType<any> = {
+        name: RX_STORAGE_NAME_LEVELDB,
+        statics: RxStorageDefaultStatics,
+        async createStorageInstance<RxDocType>(params: RxStorageInstanceCreationParams<RxDocType, LevelDBSettings>): Promise<RxStorageInstance<RxDocType, LevelDBStorageInternals<RxDocType>, LevelDBSettings, any>> {
+            const levelDBConstructorProps: LevelDBInternalConstructor<RxDocType> = "level" in settings ?
+                {
+                    level: settings.level,
+                    refCount: 1,
+                    schema: params.schema,
                 }
+                :
+                {
+                    dbPath: settings.dbPath,
+                    refCount: 1,
+                    schema: params.schema,
+                };
 
-                const rxStorageInstance = new RxStorageIntanceLevelDB<RxDocType>(
-                    this,
-                    params.databaseName,
-                    params.collectionName,
-                    params.schema,
-                    internalInstance,
-                    settings
-                )
-
-                return rxStorageInstance
+            if (!internalInstance) {
+                internalInstance = await preloadData<RxDocType>(levelDBConstructorProps);
+            } else {
+                internalInstance.refCount++
             }
+
+            const rxStorageInstance = new RxStorageIntanceLevelDB<RxDocType>(
+                this,
+                params.databaseName,
+                params.collectionName,
+                params.schema,
+                internalInstance,
+                settings
+            )
+
+            return rxStorageInstance
         }
     }
-    else {
-        console.warn('already got an instance')
-    }
 
-    return levelDBInstance
+    return instance
 }
 
 

--- a/packages/leveldb/src/index.ts
+++ b/packages/leveldb/src/index.ts
@@ -48,7 +48,7 @@ async function preloadData<RxDocType>(constructorProps: LevelDBInternalConstruct
 }
 
 function getRxStorageLevel<RxDocType>(settings: LevelDBSettings): RxStorageLevelDBType<RxDocType> {
-    if (!levelDBInstance) {
+    if (true) {
         levelDBInstance = {
             name: RX_STORAGE_NAME_LEVELDB,
             statics: RxStorageDefaultStatics,

--- a/packages/leveldb/tests/init.test.ts
+++ b/packages/leveldb/tests/init.test.ts
@@ -45,4 +45,44 @@ describe("LevelDb init", () => {
 
     // await db.close()
   })
+
+  it('should be able to instanciate multiple databases in the same thread', async ({ expect }) => {
+
+    const db = await Database.createEncrypted(
+      {
+        name: databaseName,
+        encryptionKey: defaultPassword,
+        storage: createLevelDBStorage({
+          dbPath: "./db"
+        }),
+      }
+    );
+
+    await db.storeLinkSecret("first", "first")
+
+    const db2 = await Database.createEncrypted(
+      {
+        name: databaseName,
+        encryptionKey: defaultPassword,
+        storage: createLevelDBStorage({
+          dbPath: "./db2"
+        }),
+      }
+    );
+
+    await db2.storeLinkSecret("second", "second")
+
+    const firstLinkSecret = await db.getLinkSecret();
+
+    const secondLinkSecret = await db2.getLinkSecret();
+
+    expect(firstLinkSecret).toBe("first")
+    expect(secondLinkSecret).toBe("second")
+
+    await db.clear()
+    await db2.clear()
+
+
+
+  })
 })


### PR DESCRIPTION
We are hitting a problem in Ahau tests where we start two of our peers, each trues to start  an agent (in a different path) but this global variable says "oh, there's already another db there!" and then it crashes the tests.

The change in here is more a map-pin than actual solution. I think it's fine to let levelDB handle it's own lockfile stuff?